### PR TITLE
RST-1268: Removing waiting applications from home page

### DIFF
--- a/app/assets/javascripts/gtm_track_timestamps.js
+++ b/app/assets/javascripts/gtm_track_timestamps.js
@@ -39,6 +39,29 @@ window.moj.Modules.GtmTrackTimestamps = {
     });
   },
 
+  evidenceApplication: function() {
+    var timestamps = this.getTimestamps()
+
+    dataLayer.push({
+      'event': 'Evidence_Application_Timestamp',
+      'hompageTimestamp': timestamps.homepage,
+      'evidenceApplicationTimestamp': timestamps.currentPage,
+      'transitionTimeInMs': timestamps.transitionTimeInMs
+    });
+  },
+
+  partPaymentApplication: function() {
+    var timestamps = this.getTimestamps()
+
+    dataLayer.push({
+      'event': 'Part_Payment_Application_Timestamp',
+      'hompageTimestamp': timestamps.homepage,
+      'partPaymentApplicationTimestamp': timestamps.currentPage,
+      'transitionTimeInMs': timestamps.transitionTimeInMs
+    });
+  },
+
+
   evidence: function() {
     var timestamps = this.getTimestamps()
 
@@ -112,11 +135,13 @@ window.moj.Modules.GtmTrackTimestamps = {
   },
 
   trackLinksClicked: function() {
-    $('.waiting-for-evidence a').click(function(){
+    $('a.waiting-for-evidence').click(function(){
+      console.log('evidence');
       moj.Modules.GtmTrackTimestamps.sectionLinkClick('waiting-for-evidence-section');
     });
 
-    $('.waiting-for-part_payment a').click(function(){
+    $('a.waiting-for-part_payment').click(function(){
+      console.log('part');
       moj.Modules.GtmTrackTimestamps.sectionLinkClick('waiting-for-part-payment-section');
     });
 

--- a/app/assets/javascripts/gtm_track_timestamps.js
+++ b/app/assets/javascripts/gtm_track_timestamps.js
@@ -136,12 +136,10 @@ window.moj.Modules.GtmTrackTimestamps = {
 
   trackLinksClicked: function() {
     $('a.waiting-for-evidence').click(function(){
-      console.log('evidence');
       moj.Modules.GtmTrackTimestamps.sectionLinkClick('waiting-for-evidence-section');
     });
 
     $('a.waiting-for-part_payment').click(function(){
-      console.log('part');
       moj.Modules.GtmTrackTimestamps.sectionLinkClick('waiting-for-part-payment-section');
     });
 

--- a/app/controllers/evidence_checks_controller.rb
+++ b/app/controllers/evidence_checks_controller.rb
@@ -1,4 +1,10 @@
 class EvidenceChecksController < ApplicationController
+  skip_after_action :verify_authorized, only: :index
+
+  def index
+    @waiting_for_evidence = LoadApplications.waiting_for_evidence(current_user)
+  end
+
   def show
     authorize evidence_check
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,7 +5,6 @@ class HomeController < ApplicationController
   def index
     manager_setup_progress
     load_graphs_for_admin
-    load_waiting_applications
     load_defaults
   end
 
@@ -41,13 +40,6 @@ class HomeController < ApplicationController
     if current_user.admin?
       @total_type_count = BenefitCheck.group(:dwp_result).count
       @time_of_day_count = BenefitCheck.group_by_hour_of_day("created_at", format: '%l %p').count
-    end
-  end
-
-  def load_waiting_applications
-    unless current_user.admin?
-      assign_waiting_for_evidence
-      assign_waiting_for_part_payment
     end
   end
 

--- a/app/controllers/part_payments_controller.rb
+++ b/app/controllers/part_payments_controller.rb
@@ -1,10 +1,16 @@
 class PartPaymentsController < ApplicationController
-  before_action :authorize_part_payment_update, except: :show
+  skip_after_action :verify_authorized, only: :index
+
+  before_action :authorize_part_payment_update, except: [:show, :index]
   before_action only: [:show, :accuracy, :summary, :confirmation, :return_letter] do
     track_application(application)
   end
 
   include SectionViewsHelper
+
+  def index
+    @waiting_for_part_payment = LoadApplications.waiting_for_part_payment(current_user)
+  end
 
   def show
     authorize part_payment

--- a/app/views/evidence_checks/index.html.slim
+++ b/app/views/evidence_checks/index.html.slim
@@ -1,1 +1,7 @@
 = render('home/waiting_applications', type: :evidence, list: @waiting_for_evidence, start_path: :evidence_path)
+
+- content_for(:javascripts)
+  javascript:
+    $(document).ready(function () {
+      moj.Modules.GtmTrackTimestamps.evidenceApplication();
+    });

--- a/app/views/evidence_checks/index.html.slim
+++ b/app/views/evidence_checks/index.html.slim
@@ -1,0 +1,1 @@
+= render('home/waiting_applications', type: :evidence, list: @waiting_for_evidence, start_path: :evidence_path)

--- a/app/views/home/_waiting_applications.html.slim
+++ b/app/views/home/_waiting_applications.html.slim
@@ -1,5 +1,5 @@
-h3.heading-medium.heading-icon.util_mt-medium.util_mb-0 *{class: "heading-icon-#{type}"}
-  =t("#{type}.dashboard.heading")
+header#head
+  h2.heading-xlarge =t("#{type}.dashboard.heading")
 
 - if list.present?
   table *{class: "waiting-for-#{type}"}

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -66,8 +66,16 @@ h1.visuallyhidden Help with fees - Staff application
   - if @search_results
     = render('home/search_results', type: :search_results, list: @search_results)
   = render('home/last_updated_applications', type: :updated_applications, list: @last_updated_applications)
-  = render('home/waiting_applications', type: :evidence, list: @waiting_for_evidence, start_path: :evidence_path)
-  = render('home/waiting_applications', type: :part_payment, list: @waiting_for_part_payment, start_path: :part_payment_path)
+
+
+  h3.heading-medium.heading-icon.util_mt-medium.util_mb-0 *{class: "heading-icon-evidence"}
+    =t("evidence.dashboard.heading")
+  = link_to t("evidence.dashboard.heading"), evidence_checks_path
+
+  h3.heading-medium.heading-icon.util_mt-medium.util_mb-0 *{class: "heading-icon-part_payment"}
+    =t("part_payment.dashboard.heading")
+  = link_to t("part_payment.dashboard.heading"), part_payments_path
+
   = render('home/processed_and_deleted_aplications')
 
 - if policy(:report).index? || policy(:office).index?

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -69,12 +69,16 @@ h1.visuallyhidden Help with fees - Staff application
 
 
   h3.heading-medium.heading-icon.util_mt-medium.util_mb-0 *{class: "heading-icon-evidence"}
-    =t("evidence.dashboard.heading")
-  = link_to t("evidence.dashboard.heading"), evidence_checks_path
-
-  h3.heading-medium.heading-icon.util_mt-medium.util_mb-0 *{class: "heading-icon-part_payment"}
-    =t("part_payment.dashboard.heading")
-  = link_to t("part_payment.dashboard.heading"), part_payments_path
+    =t("in_progress_applications.title")
+  table.in-progress-applications
+    caption.visuallyhidden = t('completed_applications.caption')
+    tbody
+      tr
+        td
+          = link_to t("evidence.dashboard.heading"), evidence_checks_path
+      tr
+        td
+          = link_to t("part_payment.dashboard.heading"), part_payments_path
 
   = render('home/processed_and_deleted_aplications')
 

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -75,10 +75,10 @@ h1.visuallyhidden Help with fees - Staff application
     tbody
       tr
         td
-          = link_to t("evidence.dashboard.heading"), evidence_checks_path
+          = link_to t("evidence.dashboard.heading"), evidence_checks_path, class: 'waiting-for-evidence'
       tr
         td
-          = link_to t("part_payment.dashboard.heading"), part_payments_path
+          = link_to t("part_payment.dashboard.heading"), part_payments_path, class: 'waiting-for-part_payment'
 
   = render('home/processed_and_deleted_aplications')
 

--- a/app/views/part_payments/index.html.slim
+++ b/app/views/part_payments/index.html.slim
@@ -1,0 +1,1 @@
+= render('home/waiting_applications', type: :part_payment, list: @waiting_for_part_payment, start_path: :part_payment_path)

--- a/app/views/part_payments/index.html.slim
+++ b/app/views/part_payments/index.html.slim
@@ -1,1 +1,7 @@
 = render('home/waiting_applications', type: :part_payment, list: @waiting_for_part_payment, start_path: :part_payment_path)
+
+- content_for(:javascripts)
+  javascript:
+    $(document).ready(function () {
+      moj.Modules.GtmTrackTimestamps.partPaymentApplication();
+    });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,8 @@ en-GB:
   completed_applications:
     title: Completed
     caption: Completed applications
+  in_progress_applications:
+    title: In progress
   processed_applications:
     table_header:
       reference: Reference

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,9 +64,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :evidence_checks, only: :show
+  resources :evidence_checks, only: [:index, :show]
 
-  resources :part_payments, only: :show do
+  resources :part_payments, only: [:index, :show] do
     member do
       get :accuracy
       post :accuracy_save

--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -1,7 +1,15 @@
 Feature: My dashboard
 
   Background: Signed in as a user
-    Given I am signed in as a user that has processed multiple applications
+    Given I successfully sign in as a user
+
+  Scenario: In progress applications - waiting for evidence
+    When I click on waiting for evidence
+    Then I should be taken to evidence checks page
+
+  Scenario: In progress applications - waiting for part-payment
+    When I click on waiting for part-payment
+    Then I should be taken to part payments page
 
   @wip @manual
   Scenario: View profile

--- a/features/step_definitions/evidence_steps.rb
+++ b/features/step_definitions/evidence_steps.rb
@@ -43,7 +43,7 @@ Then("I should see whather the applicant is eligible for help with fees") do
 end
 
 Then("I should see the processing summmary") do
-  date_processed = Time.zone.now.strftime('%d %B %Y')
+  date_processed = Time.zone.now.strftime('%-d %B %Y')
   expect(evidence_accuracy_page.content).to have_processing_summary
   expect(page.text).to have_content date_processed
 end

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -24,8 +24,7 @@ When("I successfully sign in as admin") do
 end
 
 Then("I am taken to my user dashboard") do
-  expect(sign_in_page.content).to have_waiting_for_evidence
-  expect(sign_in_page.content).to have_waiting_for_part_payment
+  expect(sign_in_page.content).to have_in_progress_applications
   expect(sign_in_page.content).to have_your_last_applications
   expect(sign_in_page.content).to have_completed_applications
   expect(sign_in_page.content).to have_no_generate_reports
@@ -35,8 +34,7 @@ end
 Then("I am taken to my admin dashboard") do
   expect(sign_in_page.content).to have_generate_reports
   expect(sign_in_page.content).to have_view_offices
-  expect(sign_in_page.content).to have_no_waiting_for_evidence
-  expect(sign_in_page.content).to have_no_waiting_for_part_payment
+  expect(sign_in_page.content).to have_no_in_progress_applications
   expect(sign_in_page.content).to have_no_your_last_applications
   expect(sign_in_page.content).to have_no_completed_applications
 end

--- a/features/step_definitions/user_dashboard_steps.rb
+++ b/features/step_definitions/user_dashboard_steps.rb
@@ -1,7 +1,3 @@
-Given("I am signed in as a user") do
-  binding.pry
-end
-
 When("I click on waiting for evidence") do
   expect(dashboard_page.content).to have_in_progress_header
   click_link('Waiting for evidence')

--- a/features/step_definitions/user_dashboard_steps.rb
+++ b/features/step_definitions/user_dashboard_steps.rb
@@ -1,3 +1,25 @@
+Given("I am signed in as a user") do
+  binding.pry
+end
+
+When("I click on waiting for evidence") do
+  expect(dashboard_page.content).to have_in_progress_header
+  click_link('Waiting for evidence')
+end
+
+Then("I should be taken to evidence checks page") do
+  expect(current_path).to include '/evidence_checks'
+end
+
+When("I click on waiting for part-payment") do
+  expect(dashboard_page.content).to have_in_progress_header
+  click_link('Waiting for part-payment')
+end
+
+Then("I should be taken to part payments page") do
+  expect(current_path).to include '/part_payments'
+end
+
 When("I click on view profile") do
   user_dashboard_page.view_profile.click
 end

--- a/features/support/page_objects/dashboard_page.rb
+++ b/features/support/page_objects/dashboard_page.rb
@@ -5,6 +5,7 @@ class DashboardPage < BasePage
   section :content, '#content' do
     element :look_up_button, 'input[value="Look up"]'
     element :start_now_button, 'input[value="Start now"]'
+    element :in_progress_header, 'h3', text: 'In progress'
     element :processed_applications, 'a', text: 'Processed applications'
     element :last_application, 'td', text: 'Smith'
     element :last_application_link, 'a', text: '1'

--- a/features/support/page_objects/sign_in_page.rb
+++ b/features/support/page_objects/sign_in_page.rb
@@ -8,9 +8,8 @@ class SignInPage < BasePage
   section :content, '#content' do
     element :generate_reports, 'h3', text: 'Generate reports'
     element :view_offices, 'h3', text: 'View offices'
-    element :waiting_for_evidence, 'h3', text: 'Waiting for evidence'
-    element :waiting_for_part_payment, 'h3', text: 'Waiting for part-payment'
     element :your_last_applications, 'h3', text: 'Your last applications'
+    element :in_progress_applications, 'h3', text: 'In progress'
     element :completed_applications, 'h3', text: 'Completed'
     element :user_email, '#user_email'
     element :user_password, '#user_password'

--- a/spec/controllers/evidence_checks_controller_spec.rb
+++ b/spec/controllers/evidence_checks_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe EvidenceChecksController, type: :controller do
+  let(:office) { create :office }
+  let(:user) { create :staff, office: office }
+
+  before do
+    sign_in user
+  end
+
+  describe 'GET #index' do
+    before do
+      allow(LoadApplications).to receive(:waiting_for_evidence).with(user).and_return ['waiting apps']
+      get :index
+    end
+
+    it 'returns the correct status code' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template(:index)
+    end
+
+    describe 'assigns the view models' do
+      it 'loads waiting_for_part_payment application for current user' do
+        expect(assigns(:waiting_for_evidence)).to eql(['waiting apps'])
+      end
+    end
+  end
+end

--- a/spec/controllers/part_payments_controller_spec.rb
+++ b/spec/controllers/part_payments_controller_spec.rb
@@ -28,6 +28,27 @@ RSpec.describe PartPaymentsController, type: :controller do
     allow(Views::PartPayment::Result).to receive(:new).with(part_payment).and_return(part_payment_result)
   end
 
+  describe 'GET #index' do
+    before do
+      allow(LoadApplications).to receive(:waiting_for_part_payment).with(user).and_return ['waiting apps']
+      get :index
+    end
+
+    it 'returns the correct status code' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template(:index)
+    end
+
+    describe 'assigns the view models' do
+      it 'loads waiting_for_part_payment application for current user' do
+        expect(assigns(:waiting_for_part_payment)).to eql(['waiting apps'])
+      end
+    end
+  end
+
   describe 'GET #show' do
     before do
       get :show, id: part_payment.id

--- a/spec/features/evidence-checks/evidence_check_part_payment_flow_spec.rb
+++ b/spec/features/evidence-checks/evidence_check_part_payment_flow_spec.rb
@@ -35,6 +35,7 @@ RSpec.feature 'Part payment application with evidence check', type: :feature do
     expect(evidence_check_rendered?).to be true
 
     click_link 'Back to start'
+    visit evidence_checks_path
 
     within('table.waiting-for-evidence') do
       click_link application.reload.reference

--- a/spec/features/evidence/applications_awaiting_evidence_are_displayed_on_dashboard_spec.rb
+++ b/spec/features/evidence/applications_awaiting_evidence_are_displayed_on_dashboard_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Applications awaiting evidence are displayed on dashboard', type:
   end
 
   scenario 'User is presented the list of applications awaiting evidence only for their office' do
-    visit root_path
+    visit evidence_checks_path
 
     within '.waiting-for-evidence' do
       expect(page).to have_content(application1.reference)
@@ -33,7 +33,7 @@ RSpec.feature 'Applications awaiting evidence are displayed on dashboard', type:
   end
 
   scenario 'applications by deleted users are shown' do
-    visit root_path
+    visit evidence_checks_path
 
     within '.waiting-for-evidence' do
       expect(page).to have_content(application3.reference)

--- a/spec/features/no_evidence_check/rst_985_spec.rb
+++ b/spec/features/no_evidence_check/rst_985_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Application is not evidence check when income is above threshold'
     end
 
     scenario 'finishing EV check and creating new application with same NINO' do
-      visit home_index_url
+      visit evidence_checks_path
       within(:css, '.waiting-for-evidence') do
         expect(page).to have_content(application1.reference)
         expect(page).to have_content(application2.reference)
@@ -74,6 +74,7 @@ RSpec.feature 'Application is not evidence check when income is above threshold'
 
       click_link application1.reference
       expect(page).to have_text "#{application1.reference} - Waiting for evidence"
+
       click_link 'Start now'
       choose 'Yes, the evidence is for the correct applicant and dated in the last 3 months'
       click_button 'Next'
@@ -83,12 +84,14 @@ RSpec.feature 'Application is not evidence check when income is above threshold'
       click_link 'Next'
       click_button 'Complete processing'
       expect(page).to have_content('Processing complete')
-      visit home_index_url
 
+      visit evidence_checks_path
       within(:css, '.waiting-for-evidence') do
         expect(page).not_to have_content(application1.reference)
         expect(page).to have_content(application2.reference)
       end
+
+      visit home_index_path
 
       click_button 'Start now'
       fill_personal_details('AB123456D')

--- a/spec/features/online_applications/evidence_check_spec.rb
+++ b/spec/features/online_applications/evidence_check_spec.rb
@@ -48,6 +48,7 @@ RSpec.feature 'Online application processing Evidence check', type: :feature do
     expect(page).to have_text 'Evidence of income needs to be checked'
     click_link 'Back to start'
 
+    click_link 'Waiting for evidence'
     reference = Application.last.reference
     within(:xpath, './/table[@class="waiting-for-evidence"]') do
       click_link reference
@@ -58,8 +59,11 @@ RSpec.feature 'Online application processing Evidence check', type: :feature do
     click_link 'Return application'
     click_button 'Finish'
 
+    click_link 'Waiting for part-payment'
     expect(page).to have_text('There are no applications waiting for part-payment')
     online_application_2
+
+    visit home_index_url
 
     fill_in 'Reference', with: online_application_2.reference
     click_button 'Look up'
@@ -70,6 +74,8 @@ RSpec.feature 'Online application processing Evidence check', type: :feature do
     # because there is a flag from previous check
     expect(page).to have_text 'Evidence of income needs to be checked'
     click_link 'Back to start'
+
+    click_link 'Waiting for evidence'
     within(:xpath, './/table[@class="waiting-for-evidence"]') do
       click_link Application.last.reference
     end

--- a/spec/features/part_payments/applications_awaiting_payment_are_displayed_on_dashboard_spec.rb
+++ b/spec/features/part_payments/applications_awaiting_payment_are_displayed_on_dashboard_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Applications awaiting payment are displayed on dashboard', type: 
   end
 
   scenario 'User is presented the list of applications awaiting payment only for their office' do
-    visit root_path
+    visit part_payments_path
 
     within '.waiting-for-part_payment' do
       expect(page).to have_content(application1.reference)
@@ -33,7 +33,7 @@ RSpec.feature 'Applications awaiting payment are displayed on dashboard', type: 
   end
 
   scenario 'applications by deleted users are shown' do
-    visit root_path
+    visit part_payments_path
 
     within '.waiting-for-part_payment' do
       expect(page).to have_content(application4.reference)

--- a/spec/features/return_applications/return_evidence_checkable_applications_spec.rb
+++ b/spec/features/return_applications/return_evidence_checkable_applications_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'When evidence checkable applications are returned', type: :featur
 
   context 'when on home page' do
 
-    before { visit root_path }
+    before { visit evidence_checks_path }
 
     scenario 'shows the applications that should be checked for evidence' do
       within '.waiting-for-evidence' do
@@ -38,7 +38,6 @@ RSpec.feature 'When evidence checkable applications are returned', type: :featur
       click_link application1.reference
       click_link 'Return application'
       expect(page).to have_content 'Processing complete'
-      expect(page).to have_button 'Finish'
       click_button 'Finish'
       expect(page).to have_button 'Start now'
       expect(page).to have_no_content application1.reference

--- a/spec/features/return_applications/return_part_payment_applications_spec.rb
+++ b/spec/features/return_applications/return_part_payment_applications_spec.rb
@@ -15,9 +15,9 @@ RSpec.feature 'When part-payment applications are returned', type: :feature do
     login_as user
   end
 
-  context 'when on home page' do
+  context 'when on waiting for part payment page' do
 
-    before { visit root_path }
+    before { visit part_payments_path }
 
     scenario 'shows the applications that are waiting for part-payment' do
       within '.waiting-for-part_payment' do
@@ -28,6 +28,7 @@ RSpec.feature 'When part-payment applications are returned', type: :feature do
 
     context 'processing an application for return' do
       before { click_link application1.reference }
+
       scenario 'shows the application data' do
         expect(page).to have_content 'Process part-payment'
         expect(page).to have_content application1.applicant.full_name
@@ -38,6 +39,7 @@ RSpec.feature 'When part-payment applications are returned', type: :feature do
         expect(page).to have_button 'Finish'
         click_button 'Finish'
         expect(page).to have_button 'Start now'
+        click_link 'Waiting for part-payment'
         within '.waiting-for-part_payment' do
           expect(page).to have_no_content(application1.reference)
         end


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RST-1268

### Change description ###
Removing "Waiting for part-payment" and "Waiting for evidence check" lists from the homepage and moving them to their own page. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
